### PR TITLE
Simplify jobs files

### DIFF
--- a/drivers/run-jawf-production.csh
+++ b/drivers/run-jawf-production.csh
@@ -9,32 +9,32 @@
 #######################################################################################
 #
 
-# --- Get the run-time date for generating the geotiff files ---
+# --- Set the time period ending date for generating the geotiff files ---
 
 # Default date!
 
-set runDate = `date +%Y%m%d --d 'today'`
+set upDate = `date +%Y%m%d --d '2 days ago'`
 
 # Override the default with a date from the command line if supplied!
 
 if ($#argv >= 1) then
-    set runDate = $1
+    set upDate = $1
 endif
 
 # Validate the date!
 
-set date_test = `date --d ${runDate}`
+set date_test = `date --d ${upDate}`
 echo
 
 if ($?) then
-   echo The date $runDate is invalid!
+   echo The date $upDate is invalid!
    goto error
 else
-   echo The date $runDate has been validated!
+   echo The date $upDate has been validated!
 endif
 
-set mnum = `date +%m --d ${runDate}`
-set mday = `date +%d --d ${runDate}`
+set mnum = `date +%m --d ${upDate}`
+set mday = `date +%d --d ${upDate}`
 
 # --- Set up failure flag ---
 
@@ -42,11 +42,9 @@ set failure = 0
 
 # --- Update precipitation archive ---
 
-set precipDate = `date +%Y%m%d --d "${runDate}-2days"`
-
 echo
 echo Updating CMORPH-Gauge merge precipitation archive
-perl ${JAWF_GEOTIFFS}/scripts/update-precipitation-archive.pl -d ${precipDate}
+perl ${JAWF_GEOTIFFS}/scripts/update-precipitation-archive.pl -d ${upDate}
 
 if ( $status != 0) then
     set failure = 1
@@ -56,13 +54,13 @@ endif
 
 echo
 echo Generating daily and weekly JAWF geotiffs
-perl ${JAWF_GEOTIFFS}/scripts/generate-geotiffs.pl -j ${JAWF_GEOTIFFS}/jobs/daily-temperature.jobs -d ${runDate}
+perl ${JAWF_GEOTIFFS}/scripts/generate-geotiffs.pl -j ${JAWF_GEOTIFFS}/jobs/daily-temperature.jobs -d ${upDate}
 
 if ( $status != 0) then
     set failure = 1
 endif
 
-perl ${JAWF_GEOTIFFS}/scripts/generate-geotiffs.pl -j ${JAWF_GEOTIFFS}/jobs/daily-precipitation.jobs -d ${runDate}
+perl ${JAWF_GEOTIFFS}/scripts/generate-geotiffs.pl -j ${JAWF_GEOTIFFS}/jobs/daily-precipitation.jobs -d ${upDate}
 
 if ( $status != 0) then
     set failure = 1
@@ -73,13 +71,13 @@ endif
 if ( $mday == '02' ) then
     echo
     echo Generating monthly and seasonal geotiffs
-    perl ${JAWF_GEOTIFFS}/scripts/generate-geotiffs.pl -j ${JAWF_GEOTIFFS}/jobs/monthly-temperature.jobs -d ${runDate}
+    perl ${JAWF_GEOTIFFS}/scripts/generate-geotiffs.pl -j ${JAWF_GEOTIFFS}/jobs/monthly-temperature.jobs -d ${upDate}
 
     if ( $status != 0 ) then
         set failure = 1
     endif
 
-    perl ${JAWF_GEOTIFFS}/scripts/generate-geotiffs.pl -j ${JAWF_GEOTIFFS}/jobs/monthly-precipitation.jobs -d ${runDate}
+    perl ${JAWF_GEOTIFFS}/scripts/generate-geotiffs.pl -j ${JAWF_GEOTIFFS}/jobs/monthly-precipitation.jobs -d ${upDate}
 
     if ( $status != 0 ) then
         set failure = 1
@@ -90,13 +88,13 @@ if ( $mday == '02' ) then
     if ($mnum == '01' ) then
         echo
         echo Generating annual geotiffs
-        perl ${JAWF_GEOTIFFS}/scripts/generate-geotiffs.pl -j ${JAWF_GEOTIFFS}/jobs/annual-temperature.jobs -d ${runDate}
+        perl ${JAWF_GEOTIFFS}/scripts/generate-geotiffs.pl -j ${JAWF_GEOTIFFS}/jobs/annual-temperature.jobs -d ${upDate}
 
         if ( $status != 0 ) then
             set failure = 1
         endif
 
-        perl ${JAWF_GEOTIFFS}/scripts/generate-geotiffs.pl -j ${JAWF_GEOTIFFS}/jobs/annual-precipitation.jobs -d ${runDate}
+        perl ${JAWF_GEOTIFFS}/scripts/generate-geotiffs.pl -j ${JAWF_GEOTIFFS}/jobs/annual-precipitation.jobs -d ${upDate}
 
         if ( $status != 0 ) then
             set failure = 1
@@ -113,7 +111,7 @@ if ($failure != 0) then
 endif
 
 echo
-echo All done for ${runDate}!
+echo All done for ${upDate}!
 echo
 
 exit 0

--- a/jobs/annual-precipitation.jobs
+++ b/jobs/annual-precipitation.jobs
@@ -1,6 +1,6 @@
-gradsScript|ctlObs|ctlClimo|dateOffset|period|archiveRoot|fileRoot
+gradsScript|ctlObs|ctlClimo|period|archiveRoot|fileRoot
 #
 # CMORPH-Gauge merge 0.25 degree dataset
 #
-make-precipitation-geotiffs.gs|$PRCP_ARCHIVE/CMORPH_V0.x_BLD_0.25deg-DLY_EOD.ctl|$APP_PATH/climos/precipitation/precipitation-climatology.ctl|all|-2|year|$DEFAULT_ARCHIVE|precipitation_annual
+make-precipitation-geotiffs.gs|$PRCP_ARCHIVE/CMORPH_V0.x_BLD_0.25deg-DLY_EOD.ctl|$APP_PATH/climos/precipitation/precipitation-climatology.ctl|all|year|$DEFAULT_ARCHIVE|precipitation_annual
 #

--- a/jobs/annual-temperature.jobs
+++ b/jobs/annual-temperature.jobs
@@ -1,10 +1,10 @@
-gradsScript|ctlObs|ctlClimo|dateOffset|period|archiveRoot|fileRoot
+gradsScript|ctlObs|ctlClimo|period|archiveRoot|fileRoot
 #
 # Primary dataset
 #
-make-temperature-geotiffs.gs|$TEMP_ARCHIVE/CPC_GLOBAL_T_V0.x_10min.lnx.ctl|$APP_PATH/climos/temperature/hi-res/temperature-climatology.ctl|maxmin|-2|year|$DEFAULT_ARCHIVE|temperature_annual
+make-temperature-geotiffs.gs|$TEMP_ARCHIVE/CPC_GLOBAL_T_V0.x_10min.lnx.ctl|$APP_PATH/climos/temperature/hi-res/temperature-climatology.ctl|maxmin|year|$DEFAULT_ARCHIVE|temperature_annual
 #
 # Secondary dataset - CPC merged temperature grids - to use as an over-ocean underlay
 #
-make-temperature-geotiffs.gs|$TMERGE_OBS/grads.ctl|$TMERGE_CLIM/tmean_clim_mean_01d.ctl|mean|-2|year|$DEFAULT_ARCHIVE|temperature-ocean_annual
+make-temperature-geotiffs.gs|$TMERGE_OBS/grads.ctl|$TMERGE_CLIM/tmean_clim_mean_01d.ctl|mean|year|$DEFAULT_ARCHIVE|temperature-ocean_annual
 #

--- a/jobs/daily-precipitation.jobs
+++ b/jobs/daily-precipitation.jobs
@@ -1,8 +1,8 @@
-gradsScript|ctlObs|ctlClimo|dateOffset|period|archiveRoot|fileRoot
+gradsScript|ctlObs|ctlClimo|period|archiveRoot|fileRoot
 #
 # CMORPH-Gauge merge 0.25 degree dataset
 #
-make-precipitation-geotiffs.gs|$PRCP_ARCHIVE/CMORPH_V0.x_BLD_0.25deg-DLY_EOD.ctl|$APP_PATH/climos/precipitation/precipitation-climatology.ctl|all|-2|1|$DEFAULT_ARCHIVE|precipitation_1day
+make-precipitation-geotiffs.gs|$PRCP_ARCHIVE/CMORPH_V0.x_BLD_0.25deg-DLY_EOD.ctl|$APP_PATH/climos/precipitation/precipitation-climatology.ctl|all|1|$DEFAULT_ARCHIVE|precipitation_1day
 #
-make-precipitation-geotiffs.gs|$PRCP_ARCHIVE/CMORPH_V0.x_BLD_0.25deg-DLY_EOD.ctl|$APP_PATH/climos/precipitation/precipitation-climatology.ctl|all|-2|7|$DEFAULT_ARCHIVE|precipitation_7day
+make-precipitation-geotiffs.gs|$PRCP_ARCHIVE/CMORPH_V0.x_BLD_0.25deg-DLY_EOD.ctl|$APP_PATH/climos/precipitation/precipitation-climatology.ctl|all|7|$DEFAULT_ARCHIVE|precipitation_7day
 #

--- a/jobs/daily-temperature.jobs
+++ b/jobs/daily-temperature.jobs
@@ -1,14 +1,14 @@
-gradsScript|ctlObs|ctlClimo|dateOffset|period|archiveRoot|fileRoot
+gradsScript|ctlObs|ctlClimo|period|archiveRoot|fileRoot
 #
 # Primary dataset
 #
-make-temperature-geotiffs.gs|$TEMP_ARCHIVE/CPC_GLOBAL_T_V0.x_10min.lnx.ctl|$APP_PATH/climos/temperature/hi-res/temperature-climatology.ctl|maxmin|-2|1|$DEFAULT_ARCHIVE|temperature_1day
+make-temperature-geotiffs.gs|$TEMP_ARCHIVE/CPC_GLOBAL_T_V0.x_10min.lnx.ctl|$APP_PATH/climos/temperature/hi-res/temperature-climatology.ctl|maxmin|1|$DEFAULT_ARCHIVE|temperature_1day
 #
-make-temperature-geotiffs.gs|$TEMP_ARCHIVE/CPC_GLOBAL_T_V0.x_10min.lnx.ctl|$APP_PATH/climos/temperature/hi-res/temperature-climatology.ctl|maxmin|-2|7|$DEFAULT_ARCHIVE|temperature_7day
+make-temperature-geotiffs.gs|$TEMP_ARCHIVE/CPC_GLOBAL_T_V0.x_10min.lnx.ctl|$APP_PATH/climos/temperature/hi-res/temperature-climatology.ctl|maxmin|7|$DEFAULT_ARCHIVE|temperature_7day
 #
 # Secondary dataset - CPC merged temperature grids - to use as an over-ocean underlay
 #
-make-temperature-geotiffs.gs|$TMERGE_OBS/grads.ctl|$TMERGE_CLIM/tmean_clim_mean_01d.ctl|mean|-2|1|$DEFAULT_ARCHIVE|temperature-ocean_1day
+make-temperature-geotiffs.gs|$TMERGE_OBS/grads.ctl|$TMERGE_CLIM/tmean_clim_mean_01d.ctl|mean|1|$DEFAULT_ARCHIVE|temperature-ocean_1day
 #
-make-temperature-geotiffs.gs|$TMERGE_OBS/grads.ctl|$TMERGE_CLIM/tmean_clim_mean_01d.ctl|mean|-2|7|$DEFAULT_ARCHIVE|temperature-ocean_7day
+make-temperature-geotiffs.gs|$TMERGE_OBS/grads.ctl|$TMERGE_CLIM/tmean_clim_mean_01d.ctl|mean|7|$DEFAULT_ARCHIVE|temperature-ocean_7day
 #

--- a/jobs/monthly-precipitation.jobs
+++ b/jobs/monthly-precipitation.jobs
@@ -1,8 +1,8 @@
-gradsScript|ctlObs|ctlClimo|dateOffset|period|archiveRoot|fileRoot
+gradsScript|ctlObs|ctlClimo|period|archiveRoot|fileRoot
 #
 # CMORPH-Gauge merge 0.25 degree dataset
 #
-make-precipitation-geotiffs.gs|$PRCP_ARCHIVE/CMORPH_V0.x_BLD_0.25deg-DLY_EOD.ctl|$APP_PATH/climos/precipitation/precipitation-climatology.ctl|all|-2|month|$DEFAULT_ARCHIVE|precipitation_monthly
+make-precipitation-geotiffs.gs|$PRCP_ARCHIVE/CMORPH_V0.x_BLD_0.25deg-DLY_EOD.ctl|$APP_PATH/climos/precipitation/precipitation-climatology.ctl|all|month|$DEFAULT_ARCHIVE|precipitation_monthly
 #
-make-precipitation-geotiffs.gs|$PRCP_ARCHIVE/CMORPH_V0.x_BLD_0.25deg-DLY_EOD.ctl|$APP_PATH/climos/precipitation/precipitation-climatology.ctl|all|-2|seasonal|$DEFAULT_ARCHIVE|precipitation_seasonal
+make-precipitation-geotiffs.gs|$PRCP_ARCHIVE/CMORPH_V0.x_BLD_0.25deg-DLY_EOD.ctl|$APP_PATH/climos/precipitation/precipitation-climatology.ctl|all|seasonal|$DEFAULT_ARCHIVE|precipitation_seasonal
 #

--- a/jobs/monthly-temperature.jobs
+++ b/jobs/monthly-temperature.jobs
@@ -1,14 +1,14 @@
-gradsScript|ctlObs|ctlClimo|dateOffset|period|archiveRoot|fileRoot
+gradsScript|ctlObs|ctlClimo|period|archiveRoot|fileRoot
 #
 # Primary dataset
 #
-make-temperature-geotiffs.gs|$TEMP_ARCHIVE/CPC_GLOBAL_T_V0.x_10min.lnx.ctl|$APP_PATH/climos/temperature/hi-res/temperature-climatology.ctl|maxmin|-2|month|$DEFAULT_ARCHIVE|temperature_monthly
+make-temperature-geotiffs.gs|$TEMP_ARCHIVE/CPC_GLOBAL_T_V0.x_10min.lnx.ctl|$APP_PATH/climos/temperature/hi-res/temperature-climatology.ctl|maxmin|month|$DEFAULT_ARCHIVE|temperature_monthly
 #
-make-temperature-geotiffs.gs|$TEMP_ARCHIVE/CPC_GLOBAL_T_V0.x_10min.lnx.ctl|$APP_PATH/climos/temperature/hi-res/temperature-climatology.ctl|maxmin|-2|seasonal|$DEFAULT_ARCHIVE|temperature_seasonal
+make-temperature-geotiffs.gs|$TEMP_ARCHIVE/CPC_GLOBAL_T_V0.x_10min.lnx.ctl|$APP_PATH/climos/temperature/hi-res/temperature-climatology.ctl|maxmin|seasonal|$DEFAULT_ARCHIVE|temperature_seasonal
 #
 # Secondary dataset - CPC merged temperature grids - to use as an over-ocean underlay
 #
-make-temperature-geotiffs.gs|$TMERGE_OBS/grads.ctl|$TMERGE_CLIM/tmean_clim_mean_01d.ctl|mean|-2|month|$DEFAULT_ARCHIVE|temperature-ocean_monthly
+make-temperature-geotiffs.gs|$TMERGE_OBS/grads.ctl|$TMERGE_CLIM/tmean_clim_mean_01d.ctl|mean|month|$DEFAULT_ARCHIVE|temperature-ocean_monthly
 #
-make-temperature-geotiffs.gs|$TMERGE_OBS/grads.ctl|$TMERGE_CLIM/tmean_clim_mean_01d.ctl|mean|-2|seasonal|$DEFAULT_ARCHIVE|temperature-ocean_seasonal
+make-temperature-geotiffs.gs|$TMERGE_OBS/grads.ctl|$TMERGE_CLIM/tmean_clim_mean_01d.ctl|mean|seasonal|$DEFAULT_ARCHIVE|temperature-ocean_seasonal
 #


### PR DESCRIPTION
This fixes #13 

Changes proposed in this pull request:
- Remove dateOffset from jobs config files
- Remove dateOffset from start/end date calculations in Perl switchboard script
- Change runDate (default today) to upDate (default 2-days-ago) in driver script

@adamallgood
